### PR TITLE
Convert site to React frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This repository contains a simple fantasy baseball challenge site that helps run
 a "runs 0–13" competition. Participants are randomly assigned MLB teams and the
 site tracks which run totals each team achieves throughout the season.
+The user interface is built with React and styled with a dark theme reminiscent
+of DraftKings.
 
 ## Setup
 
@@ -33,8 +35,9 @@ site tracks which run totals each team achieves throughout the season.
    ```bash
    python app.py
    ```
-   Visit `http://localhost:5000` in a browser to view each participant, their
-   assigned team and the list of run totals that team has scored so far.
+   Visit `http://localhost:5000` to view the React interface. The app fetches
+   the assignment and scoreboard data from `/api/data` and displays a table in
+   a dark theme inspired by DraftKings.
 
 The ultimate goal is for a team to record every run total from 0 through 13.
 The sample rules in the project description award prizes for milestones such as

--- a/app.py
+++ b/app.py
@@ -1,23 +1,8 @@
-from flask import Flask, render_template_string
+from flask import Flask, jsonify, send_from_directory
 import json
+import os
 
-app = Flask(__name__)
-
-INDEX_TMPL = """
-<!doctype html>
-<title>Fantasy Runs Challenge</title>
-<h1>Fantasy Runs Challenge</h1>
-<table border="1" cellpadding="5">
-<tr><th>Participant</th><th>Team</th><th>Runs 0-13</th></tr>
-{% for participant, team in assignments.items() %}
-  <tr>
-    <td>{{ participant }}</td>
-    <td>{{ team }}</td>
-    <td>{{ scoreboard.get(team, []) }}</td>
-  </tr>
-{% endfor %}
-</table>
-"""
+app = Flask(__name__, static_folder="frontend", static_url_path="")
 
 
 def load_data():
@@ -28,10 +13,20 @@ def load_data():
     return assignments, scoreboard
 
 
+@app.route("/api/data")
+def api_data():
+    assignments, scoreboard = load_data()
+    return jsonify({"assignments": assignments, "scoreboard": scoreboard})
+
+
 @app.route("/")
 def index():
-    assignments, scoreboard = load_data()
-    return render_template_string(INDEX_TMPL, assignments=assignments, scoreboard=scoreboard)
+    return send_from_directory(app.static_folder, "index.html")
+
+
+@app.route("/<path:path>")
+def static_proxy(path):
+    return send_from_directory(app.static_folder, path)
 
 
 if __name__ == "__main__":

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,41 @@
+function App() {
+  const [data, setData] = React.useState(null);
+
+  React.useEffect(() => {
+    fetch('/api/data')
+      .then(res => res.json())
+      .then(setData);
+  }, []);
+
+  if (!data) {
+    return React.createElement('div', { className: 'loading' }, 'Loading...');
+  }
+
+  const { assignments, scoreboard } = data;
+
+  return (
+    <div className="container">
+      <h1>Fantasy Runs Challenge</h1>
+      <table>
+        <thead>
+          <tr>
+            <th>Participant</th>
+            <th>Team</th>
+            <th>Runs 0-13</th>
+          </tr>
+        </thead>
+        <tbody>
+          {Object.entries(assignments).map(([participant, team]) => (
+            <tr key={participant}>
+              <td>{participant}</td>
+              <td>{team}</td>
+              <td>{(scoreboard[team] || []).join(', ')}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Fantasy Runs Challenge</title>
+  <link rel="stylesheet" href="style.css" />
+  <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel" src="app.js"></script>
+</body>
+</html>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,45 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  background-color: #0f1319;
+  color: #ffffff;
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+h1 {
+  color: #5cb85c;
+  text-align: center;
+  margin-bottom: 20px;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th, td {
+  padding: 8px;
+  border-bottom: 1px solid #444;
+}
+
+th {
+  background-color: #1b1e24;
+  color: #5cb85c;
+  text-align: left;
+}
+
+tr:nth-child(even) {
+  background-color: #1b1e24;
+}
+
+.loading {
+  color: #5cb85c;
+  text-align: center;
+  padding: 50px;
+}


### PR DESCRIPTION
## Summary
- switch Flask app to serve React files
- add React-based interface with simple dark theme reminiscent of DraftKings
- document new frontend behavior

## Testing
- `python -m py_compile app.py draft.py update_scores.py`
- `pip install -q Flask requests`
- `nohup python app.py > /tmp/server.log 2>&1 &`
- `curl -s http://localhost:5000 | head`
- `curl -s http://localhost:5000/api/data | head`


------
https://chatgpt.com/codex/tasks/task_e_68407c5a0bec832c98d414ee0596aeb6