### PR TITLE
Add tests and debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,28 @@ of DraftKings.
 The ultimate goal is for a team to record every run total from 0 through 13.
 The sample rules in the project description award prizes for milestones such as
 first team to 13 runs, first team to complete all totals, and so on.
+
+## Testing
+
+Automated tests are provided using `pytest`.
+
+1. Install the dependencies (including `pytest`):
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Run the test suite:
+   ```bash
+   pytest -v
+   ```
+
+To see detailed debug output while running any of the scripts, set the
+`LOG_LEVEL` environment variable to `DEBUG`:
+
+```bash
+LOG_LEVEL=DEBUG python update_scores.py
+```
+
+`draft.py`, `update_scores.py` and `app.py` also respect the optional
+`SCOREBOARD_FILE` and `PARTICIPANTS_FILE` environment variables which can be
+used to override the default file locations when troubleshooting.

--- a/app.py
+++ b/app.py
@@ -1,33 +1,45 @@
 from flask import Flask, jsonify, send_from_directory
 import json
+import logging
 import os
 
 app = Flask(__name__, static_folder="frontend", static_url_path="")
 
+PARTICIPANTS_FILE = os.environ.get("PARTICIPANTS_FILE", "participants.json")
+SCOREBOARD_FILE = os.environ.get("SCOREBOARD_FILE", "scoreboard.json")
+
+logger = logging.getLogger(__name__)
+
 
 def load_data():
-    with open("participants.json") as f:
+    logger.debug("Loading participants from %s", PARTICIPANTS_FILE)
+    with open(PARTICIPANTS_FILE) as f:
         assignments = json.load(f)
-    with open("scoreboard.json") as f:
+    logger.debug("Loading scoreboard from %s", SCOREBOARD_FILE)
+    with open(SCOREBOARD_FILE) as f:
         scoreboard = json.load(f)
     return assignments, scoreboard
 
 
 @app.route("/api/data")
 def api_data():
+    logger.debug("/api/data requested")
     assignments, scoreboard = load_data()
     return jsonify({"assignments": assignments, "scoreboard": scoreboard})
 
 
 @app.route("/")
 def index():
+    logger.debug("Serving index page")
     return send_from_directory(app.static_folder, "index.html")
 
 
 @app.route("/<path:path>")
 def static_proxy(path):
+    logger.debug("Serving static file: %s", path)
     return send_from_directory(app.static_folder, path)
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG if os.environ.get("LOG_LEVEL") == "DEBUG" else logging.INFO)
     app.run(debug=True)

--- a/draft.py
+++ b/draft.py
@@ -1,4 +1,6 @@
 import json
+import logging
+import os
 import random
 import sys
 
@@ -36,31 +38,43 @@ TEAMS = [
 ]
 
 
+PARTICIPANTS_FILE = os.environ.get("PARTICIPANTS_FILE", "participants.json")
+SCOREBOARD_FILE = os.environ.get("SCOREBOARD_FILE", "scoreboard.json")
+
+logger = logging.getLogger(__name__)
+
+
 def main(participants_file: str):
+    logger.debug("Reading participants from %s", participants_file)
     with open(participants_file) as f:
         participants = [line.strip() for line in f if line.strip()]
 
     if len(participants) != 30:
+        logger.error("Expected 30 participants but got %d", len(participants))
         raise SystemExit("Exactly 30 participants are required")
 
     random.shuffle(TEAMS)
+    logger.debug("Teams after shuffle: %s", TEAMS)
 
     assignments = dict(zip(participants, TEAMS))
 
     # Save participant assignments
-    with open("participants.json", "w") as f:
+    logger.debug("Writing assignments to %s", PARTICIPANTS_FILE)
+    with open(PARTICIPANTS_FILE, "w") as f:
         json.dump(assignments, f, indent=2)
 
     # Initialize scoreboard
     scoreboard = {team: [] for team in TEAMS}
-    with open("scoreboard.json", "w") as f:
+    logger.debug("Initializing scoreboard in %s", SCOREBOARD_FILE)
+    with open(SCOREBOARD_FILE, "w") as f:
         json.dump(scoreboard, f, indent=2)
 
-    print("Draft complete. Assignments written to participants.json")
+    logger.info("Draft complete. Assignments written to %s", PARTICIPANTS_FILE)
 
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
         print("Usage: python draft.py PARTICIPANTS_FILE")
         sys.exit(1)
+    logging.basicConfig(level=logging.DEBUG if os.environ.get("LOG_LEVEL") == "DEBUG" else logging.INFO)
     main(sys.argv[1])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 Flask
 requests
+
+pytest

--- a/tests/test_draft.py
+++ b/tests/test_draft.py
@@ -1,0 +1,30 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import draft
+
+
+def test_draft_creates_files(monkeypatch, tmp_path):
+    participants = [f"P{i}" for i in range(30)]
+    participants_file = tmp_path / "participants.txt"
+    participants_file.write_text("\n".join(participants))
+
+    participants_json = tmp_path / "participants.json"
+    scoreboard_file = tmp_path / "scoreboard.json"
+    monkeypatch.setenv("PARTICIPANTS_FILE", str(participants_json))
+    monkeypatch.setenv("SCOREBOARD_FILE", str(scoreboard_file))
+
+    monkeypatch.chdir(tmp_path)
+    draft.main(str(participants_file))
+
+    assert participants_json.exists()
+    assert scoreboard_file.exists()
+
+    data = json.loads(scoreboard_file.read_text())
+    assert len(data) == len(draft.TEAMS)
+    for scores in data.values():
+        assert scores == []

--- a/tests/test_update_scores.py
+++ b/tests/test_update_scores.py
@@ -1,0 +1,39 @@
+import json
+from types import SimpleNamespace
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import update_scores
+
+
+def test_update_for_date(monkeypatch, tmp_path):
+    scoreboard_file = tmp_path / "scoreboard.json"
+    scoreboard_file.write_text(json.dumps({"Test Team": []}))
+    monkeypatch.setenv("SCOREBOARD_FILE", str(scoreboard_file))
+    update_scores.SCOREBOARD_FILE = str(scoreboard_file)
+
+    sample_games = [{
+        "teams": {
+            "home": {"team": {"name": "Test Team"}, "score": 5},
+            "away": {"team": {"name": "Other"}, "score": 3}
+        }
+    }]
+
+    class FakeResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"dates": [{"games": sample_games}]}
+
+    def fake_get(url, timeout):
+        return FakeResponse()
+
+    monkeypatch.setattr(update_scores, "requests", SimpleNamespace(get=fake_get))
+
+    update_scores.update_for_date("2022-01-01")
+
+    data = json.loads(scoreboard_file.read_text())
+    assert data["Test Team"] == [5]

--- a/update_scores.py
+++ b/update_scores.py
@@ -1,32 +1,43 @@
 import datetime
 import json
+import logging
+import os
 import sys
 from typing import Dict
 
 import requests
 
 SCHEDULE_URL = "https://statsapi.mlb.com/api/v1/schedule?sportId=1&date={date}"
+SCOREBOARD_FILE = os.environ.get("SCOREBOARD_FILE", "scoreboard.json")
+
+logger = logging.getLogger(__name__)
 
 
 def load_scoreboard() -> Dict[str, list]:
-    with open("scoreboard.json") as f:
+    logger.debug("Loading scoreboard from %s", SCOREBOARD_FILE)
+    with open(SCOREBOARD_FILE) as f:
         return json.load(f)
 
 
 def save_scoreboard(scoreboard: Dict[str, list]):
-    with open("scoreboard.json", "w") as f:
+    logger.debug("Saving scoreboard to %s", SCOREBOARD_FILE)
+    with open(SCOREBOARD_FILE, "w") as f:
         json.dump(scoreboard, f, indent=2)
 
 
 def fetch_games(date: str) -> list:
     url = SCHEDULE_URL.format(date=date)
+    logger.debug("Fetching games from %s", url)
     response = requests.get(url, timeout=30)
     response.raise_for_status()
     data = response.json()
-    return data.get("dates", [{}])[0].get("games", [])
+    games = data.get("dates", [{}])[0].get("games", [])
+    logger.debug("Fetched %d games", len(games))
+    return games
 
 
 def update_for_date(date: str):
+    logger.debug("Updating scores for %s", date)
     games = fetch_games(date)
     scoreboard = load_scoreboard()
 
@@ -35,8 +46,10 @@ def update_for_date(date: str):
             team = game["teams"][side]["team"]["name"]
             runs = game["teams"][side]["score"]
             if team not in scoreboard:
+                logger.debug("Skipping untracked team %s", team)
                 continue
             if runs not in scoreboard[team]:
+                logger.debug("Adding run total %s for %s", runs, team)
                 scoreboard[team].append(runs)
                 scoreboard[team].sort()
 
@@ -45,6 +58,7 @@ def update_for_date(date: str):
 
 
 def main():
+    logging.basicConfig(level=logging.DEBUG if os.environ.get("LOG_LEVEL") == "DEBUG" else logging.INFO)
     if len(sys.argv) > 1:
         date = sys.argv[1]
     else:


### PR DESCRIPTION
## Summary
- add pytest to requirements
- implement debug logging and env var support across scripts
- add automated tests for drafting and score updates
- document testing and debug options in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407d80b184832caf9bd26bcc0505cf