### PR TITLE
Improve scoreboard UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ of DraftKings.
    python app.py
    ```
    Visit `http://localhost:5000` to view the React interface. The app fetches
-   the assignment and scoreboard data from `/api/data` and displays a table in
-   a dark theme inspired by DraftKings.
+   the assignment and scoreboard data from `/api/data`. Participants are sorted
+   by progress and the table now shows a column for each run total from 0 to 13
+   with a check mark when a team has achieved that number of runs.
 
 The ultimate goal is for a team to record every run total from 0 through 13.
 The sample rules in the project description award prizes for milestones such as

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -13,6 +13,16 @@ function App() {
 
   const { assignments, scoreboard } = data;
 
+  const RUN_TOTALS = Array.from({ length: 14 }, (_, i) => i);
+
+  const rows = Object.entries(assignments)
+    .map(([participant, team]) => ({
+      participant,
+      team,
+      achieved: scoreboard[team] || [],
+    }))
+    .sort((a, b) => b.achieved.length - a.achieved.length);
+
   return (
     <div className="container">
       <h1>Fantasy Runs Challenge</h1>
@@ -21,15 +31,21 @@ function App() {
           <tr>
             <th>Participant</th>
             <th>Team</th>
-            <th>Runs 0-13</th>
+            {RUN_TOTALS.map((n) => (
+              <th key={n} className="center">{n}</th>
+            ))}
           </tr>
         </thead>
         <tbody>
-          {Object.entries(assignments).map(([participant, team]) => (
-            <tr key={participant}>
-              <td>{participant}</td>
-              <td>{team}</td>
-              <td>{(scoreboard[team] || []).join(', ')}</td>
+          {rows.map((row) => (
+            <tr key={row.participant}>
+              <td>{row.participant}</td>
+              <td>{row.team}</td>
+              {RUN_TOTALS.map((n) => (
+                <td key={n} className="center">
+                  {row.achieved.includes(n) ? '✓' : ''}
+                </td>
+              ))}
             </tr>
           ))}
         </tbody>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -28,6 +28,10 @@ th, td {
   border-bottom: 1px solid #444;
 }
 
+.center {
+  text-align: center;
+}
+
 th {
   background-color: #1b1e24;
   color: #5cb85c;


### PR DESCRIPTION
## Summary
- show each run total 0-13 as its own column on the webpage
- sort participants by progress and center run table columns
- document the new scoreboard view in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68407f6324ac832c9af502158a11a5c3